### PR TITLE
OIP v0.1 (M1): add implementation plan, backend types and frontend API/UI for scoring & policy evaluation

### DIFF
--- a/OIP_M1_IMPLEMENTATION_PLAN.md
+++ b/OIP_M1_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,83 @@
+# OneBlock Open Identity Protocol (OIP) - M1 Implementation Plan
+
+## Scope
+This document defines a practical M1 implementation for OIP v0.1:
+- probabilistic identity outputs
+- dynamic factor lifecycle
+- contextual policy evaluation
+
+## Backend changes
+
+### 1) Core data model (`src/oneblock_backend/types.mo`)
+Add:
+- `EntityKind`
+- `FactorCategory`, `FactorStatus`, `Factor`
+- `ProbabilityScores`
+- `ContextPolicy` and requirements/weights
+- `IdentityGraph`
+- `FactorEvent` (history)
+
+### 2) State persistence (`src/oneblock_backend/main.mo`)
+Add stable+transient maps:
+- `identityGraphs`
+- `contextPolicies`
+
+Wire maps into `preupgrade` / `postupgrade`.
+
+### 3) M1 API surface
+Add methods:
+- `createIdentityGraph`
+- `addFactor`
+- `revokeFactor`
+- `createPolicy`
+- `recomputeScores`
+- `getScores`
+- `evaluatePolicy`
+
+### 4) Scoring (M1)
+Implement linear score aggregation:
+
+`Final = Σ(confidence × categoryWeight × freshness × reliability)`
+
+Outputs:
+- `human_score`
+- `uniqueness_score`
+- `trust_score`
+- `reputation_score`
+- `ai_probability`
+- `organization_probability`
+
+### 5) Policy presets
+Seed:
+- `dao-voting`
+- `finance-risk`
+
+## Frontend changes
+
+### 1) API wrappers
+Create `src/oneblock_frontend/src/api/oip/index.ts`:
+- `getScores`
+- `recomputeScores`
+- `evaluatePolicy`
+
+### 2) UI
+Create:
+- `src/oneblock_frontend/src/components/ScoresOIP.tsx`
+- `src/oneblock_frontend/src/pages/PolicyEval.tsx`
+- optional `src/oneblock_frontend/src/pages/Identity.tsx`
+
+### 3) Seed runner
+Create `src/oneblock_frontend/src/lib/oipSeed.ts` for one-click demo data.
+
+## M1 acceptance checklist
+- identity graph creation succeeds
+- factors can be added and revoked
+- scores recompute to non-zero values with demo factors
+- policy evaluation returns pass/fail + per-rule details
+- frontend can display score bars and policy results
+
+## Out of scope (M2+)
+- exponential decay as default (`exp(-λt)`)
+- trust-edge graph weighting
+- provider marketplace and signed submission gateway
+- anomaly/risk engine

--- a/src/oneblock_backend/types.mo
+++ b/src/oneblock_backend/types.mo
@@ -312,4 +312,153 @@ module {
         attestation : ?Attestation;
         visibility : Visibility;
     };
+
+    // ========== OIP v0.1 (M1) ==========
+    public type IdentityPrincipal = Text;
+    public type FactorId = Text;
+    public type PolicyId = Text;
+
+    public type EntityKind = {
+        #human;
+        #ai_agent;
+        #hybrid;
+        #organization;
+    };
+
+    public type FactorCategory = {
+        #existence;
+        #continuity;
+        #human;
+        #social;
+        #economic;
+        #reputation;
+    };
+
+    public type FactorStatus = { #active; #revoked; #expired };
+
+    public type Factor = {
+        id : FactorId;
+        principal : IdentityPrincipal;
+        category : FactorCategory;
+        factor_type : Text;
+        provider : Text;
+        value : Text;
+        verified : Bool;
+        confidence : Float;
+        reliability : Float;
+        weight_hint : Float;
+        issued_at : Timestamp;
+        updated_at : Timestamp;
+        expires_at : ?Timestamp;
+        revoked_at : ?Timestamp;
+        status : FactorStatus;
+        metadata : [MetadataEntry];
+    };
+
+    public type ProbabilityScores = {
+        human_score : Float;
+        uniqueness_score : Float;
+        trust_score : Float;
+        reputation_score : Float;
+        ai_probability : Float;
+        organization_probability : Float;
+        updated_at : Timestamp;
+        model_version : Text;
+    };
+
+    public type PolicyRequirements = {
+        min_human_score : ?Float;
+        min_uniqueness_score : ?Float;
+        min_trust_score : ?Float;
+        min_reputation_score : ?Float;
+        min_wallet_age_days : ?Nat;
+    };
+
+    public type PolicyWeights = {
+        existence : Float;
+        continuity : Float;
+        human : Float;
+        social : Float;
+        economic : Float;
+        reputation : Float;
+    };
+
+    public type ContextPolicy = {
+        policy_id : PolicyId;
+        name : Text;
+        description : Text;
+        requirements : PolicyRequirements;
+        weights : PolicyWeights;
+        decay_lambda : Float;
+        active : Bool;
+        created_at : Timestamp;
+        updated_at : Timestamp;
+    };
+
+    public type FactorEventAction = { #created; #updated; #revoked; #expired; #recomputed };
+
+    public type FactorEvent = {
+        principal : IdentityPrincipal;
+        factor_id : ?FactorId;
+        action : FactorEventAction;
+        reason : ?Text;
+        actor : Text;
+        timestamp : Timestamp;
+        metadata : [MetadataEntry];
+    };
+
+    public type IdentityGraph = {
+        principal : IdentityPrincipal;
+        entity_kind : EntityKind;
+        factors : [Factor];
+        scores : ProbabilityScores;
+        history : [FactorEvent];
+        created_at : Timestamp;
+        updated_at : Timestamp;
+    };
+
+    public type NewIdentityGraph = {
+        principal : IdentityPrincipal;
+        entity_kind : EntityKind;
+    };
+
+    public type NewFactor = {
+        principal : IdentityPrincipal;
+        category : FactorCategory;
+        factor_type : Text;
+        provider : Text;
+        value : Text;
+        verified : Bool;
+        confidence : Float;
+        reliability : Float;
+        weight_hint : Float;
+        expires_at : ?Timestamp;
+        metadata : [MetadataEntry];
+    };
+
+    public type NewContextPolicy = {
+        policy_id : PolicyId;
+        name : Text;
+        description : Text;
+        requirements : PolicyRequirements;
+        weights : PolicyWeights;
+        decay_lambda : Float;
+        active : Bool;
+    };
+
+    public type PolicyEvaluationItem = {
+        key : Text;
+        passed : Bool;
+        expected : Text;
+        actual : Text;
+    };
+
+    public type PolicyEvaluation = {
+        policy_id : PolicyId;
+        principal : IdentityPrincipal;
+        passed : Bool;
+        items : [PolicyEvaluationItem];
+        evaluated_at : Timestamp;
+    };
+
 }

--- a/src/oneblock_frontend/src/api/oip/index.ts
+++ b/src/oneblock_frontend/src/api/oip/index.ts
@@ -1,0 +1,12 @@
+import { profile } from "../profile";
+
+export const getScores = (principal: string) => profile.getScores(principal);
+
+export const recomputeScores = (principal: string, policyId?: string) =>
+  profile.recomputeScores(principal, policyId ? [policyId] : []);
+
+export const evaluatePolicy = (principal: string, policyId: string) =>
+  profile.evaluatePolicy(principal, policyId);
+
+export const createIdentityGraph = (principal: string) =>
+  profile.createIdentityGraph({ principal, entity_kind: { human: null } });

--- a/src/oneblock_frontend/src/components/ScoresOIP.tsx
+++ b/src/oneblock_frontend/src/components/ScoresOIP.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+type Scores = {
+  human_score: number;
+  uniqueness_score: number;
+  trust_score: number;
+  reputation_score: number;
+  ai_probability: number;
+  organization_probability: number;
+  model_version: string;
+  updated_at: bigint | number;
+};
+
+const toPct = (v: number) => Math.round(Math.max(0, Math.min(1, v ?? 0)) * 100);
+
+const Row = ({ label, value }: { label: string; value: number }) => (
+  <div style={{ marginBottom: 8 }}>
+    <div style={{ display: "flex", justifyContent: "space-between" }}>
+      <span>{label}</span>
+      <span>{toPct(value)}%</span>
+    </div>
+    <progress value={toPct(value)} max={100} style={{ width: "100%" }} />
+  </div>
+);
+
+export default function ScoresOIP({ scores }: { scores: Scores | null }) {
+  if (!scores) return <div>No OIP scores yet.</div>;
+
+  return (
+    <div>
+      <Row label="Human" value={scores.human_score} />
+      <Row label="Uniqueness" value={scores.uniqueness_score} />
+      <Row label="Trust" value={scores.trust_score} />
+      <Row label="Reputation" value={scores.reputation_score} />
+      <Row label="AI Probability" value={scores.ai_probability} />
+      <Row label="Organization Probability" value={scores.organization_probability} />
+      <small>Model: {scores.model_version}</small>
+    </div>
+  );
+}

--- a/src/oneblock_frontend/src/pages/PolicyEval.tsx
+++ b/src/oneblock_frontend/src/pages/PolicyEval.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import { evaluatePolicy, recomputeScores } from "../api/oip";
+
+export default function PolicyEval() {
+  const [principal, setPrincipal] = useState("oneblock:alice");
+  const [policyId, setPolicyId] = useState("dao-voting");
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState("");
+
+  const onRun = async () => {
+    setError("");
+    try {
+      await recomputeScores(principal, policyId);
+      const res: any = await evaluatePolicy(principal, policyId);
+      if ("ok" in res) setResult(res.ok);
+      else setError(res.err || "evaluation failed");
+    } catch (e: any) {
+      setError(e?.message || "evaluation failed");
+    }
+  };
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Policy Evaluation</h2>
+      <input value={principal} onChange={(e) => setPrincipal(e.target.value)} />
+      <input value={policyId} onChange={(e) => setPolicyId(e.target.value)} />
+      <button onClick={onRun}>Evaluate</button>
+      {error ? <p>{error}</p> : null}
+      {result ? <pre>{JSON.stringify(result, null, 2)}</pre> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Define a minimal M1 implementation for the OneBlock Open Identity Protocol (OIP v0.1) to support probabilistic identity outputs, factor lifecycle, and contextual policy evaluation.
- Provide a clear backend data model and API surface for creating identity graphs, managing factors, recomputing scores, and evaluating policies.
- Add a simple frontend API and UI pages/components to demo score display and policy evaluation flows.

### Description
- Add `OIP_M1_IMPLEMENTATION_PLAN.md` with scope, backend/frontend changes, scoring formula, policy presets, and an M1 acceptance checklist.
- Extend backend types in `src/oneblock_backend/types.mo` with identity primitives: `IdentityGraph`, `Factor`, `ProbabilityScores`, `ContextPolicy`, `FactorEvent`, enums (`EntityKind`, `FactorCategory`, `FactorStatus`), and request/response shapes (`NewIdentityGraph`, `NewFactor`, `PolicyEvaluation`, etc.).
- Add frontend API wrappers in `src/oneblock_frontend/src/api/oip/index.ts` exposing `getScores`, `recomputeScores`, `evaluatePolicy`, and `createIdentityGraph` that delegate to the existing `profile` API.
- Add a scores UI component `ScoresOIP.tsx` and a demo page `PolicyEval.tsx` to display score bars and run policy evaluations from the frontend.

### Testing
- No automated tests were added or executed as part of this change.
- Type additions and frontend files were added to support later implementation and integration tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ddb456a88330881b79a7d0c86809)